### PR TITLE
fixes logic error when looking for executable file

### DIFF
--- a/lib/children.c
+++ b/lib/children.c
@@ -364,7 +364,7 @@ _child_exec(struct child_s *sd, int argc, char ** args)
 	if (g_path_is_absolute(cmd))
 		real_cmd = g_strdup(cmd);
 
-	if (!real_cmd || NULL == (real_cmd = g_find_program_in_path(cmd)))
+	if (!real_cmd && NULL == (real_cmd = g_find_program_in_path(cmd)))
 		FATAL("'%s' not executable or not found in PATH:%s", cmd, g_getenv("PATH"));
 	else {
 		execve(real_cmd, args, env);


### PR DESCRIPTION
Hello everyone :smiley: 

I am setting up OpenIO. In the process, I noticed that some executable files were not found by `gridinit`. It seems the cause is a bad condition when a relative path will never be considered valid.

Changing the condition as in this commit makes `gridinit` resolve the relative path to an absolute path.

If this is not right, please let me know, I'm glad to investigate further. But it seems simple enough.

Best regards,
Conrad
