### PR TITLE
Fixes, Logging improvement

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -38,7 +38,7 @@ g_error_printf(const char *dom, int code, const char *fmt, ...)
 	str = g_strdup_vprintf (fmt, va);
 	va_end(va);
 
-	e = g_error_new(g_quark_from_static_string(dom), code, str);
+	e = g_error_new(g_quark_from_static_string(dom), code, "%s", str);
 	g_free(str);
 	return e;
 }

--- a/main/alerting.c
+++ b/main/alerting.c
@@ -84,7 +84,13 @@ gridinit_alerting_configure(const gchar *path, const gchar *symbol,
 void
 gridinit_alerting_send(int event, const char *msg)
 {
-	WARN("Process alert: %s", msg);
+	if (event == GRIDINIT_EVENT_BROKEN) {
+		ERROR("Process alert: %s", msg);
+	} else if (event == GRIDINIT_EVENT_RESTARTED) {
+		WARN("Process alert: %s", msg);
+	} else {
+		NOTICE("Process alert: %s", msg);
+	}
 
 	if (!module || !handle || !handle->send)
 		return;


### PR DESCRIPTION
- Erorr format fixed (would lead to segfaults)
- Logging can now be temporarily increased with SIGUSR1
- automatically reset after 15 minutes
- finer mapping from internal to syslog levels
- new '-v' option set raise the default verbosity (without SIGUSR1)
