### PR TITLE
Make `stop` wait for the actual termination of the children processes

### DIFF
--- a/lib/children.c
+++ b/lib/children.c
@@ -1164,6 +1164,22 @@ supervisor_children_set_ids(const gchar *key, gint32 uid, gint32 gid)
 	return 0;
 }
 
+int
+supervisor_children_set_delay_sigkill(const char *key, time_t delay)
+{
+	if (!key) {
+		errno = EINVAL;
+		return -1;
+	}
+	struct child_s *sd;
+	if (!(sd = supervisor_get_child(key))) {
+		errno = ENOENT;
+		return -1;
+	}
+	sd->delay_before_KILL = delay;
+	return 0;
+}
+
 void
 supervisor_set_callback_postfork(supervisor_postfork_f *cb, void *udata)
 {

--- a/lib/children.c
+++ b/lib/children.c
@@ -383,7 +383,7 @@ _child_start(struct child_s *sd, void *udata, supervisor_cb_f cb)
 	gint argc;
 	gchar **args;
 	struct my_rlimits_s saved_limits;
-	
+
 	if (!sd || !sd->command) {
 		errno = EINVAL;
 		return -1;
@@ -393,7 +393,7 @@ _child_start(struct child_s *sd, void *udata, supervisor_cb_f cb)
 		errno = EINVAL;
 		return -1;
 	}
-	
+
 	bzero(&saved_limits, sizeof(saved_limits));
 
 	sd->last_start_attempt = time(0);
@@ -415,7 +415,7 @@ _child_start(struct child_s *sd, void *udata, supervisor_cb_f cb)
 		if (supervisor_cb_postfork != NULL)
 			supervisor_cb_postfork(supervisor_cb_postfork_udata);
 		reset_sighandler();
-		
+
 		/* change the rights before changing the working directory */
 		if (getuid() == 0) {
 			setgid(sd->gid);
@@ -531,7 +531,7 @@ _child_can_be_restarted(struct child_s *sd)
 		return FALSE;
 
 	/* here : restart allowed */
-	if (!FLAG_HAS(sd,MASK_DELAYED))	
+	if (!FLAG_HAS(sd,MASK_DELAYED))
 		return TRUE;
 
 	/* here : restart delayed if died too early */
@@ -663,7 +663,7 @@ supervisor_children_disable_obsolete(void)
 			count ++;
 		}
 	}
-	
+
 	return count;
 }
 
@@ -683,7 +683,7 @@ supervisor_children_kill_obsolete(void)
 			}
 		}
 	}
-	
+
 	return count;
 }
 
@@ -694,7 +694,7 @@ supervisor_children_catharsis(void *udata, supervisor_cb_f cb)
 	guint count;
 	struct child_s *sd;
 	struct child_info_s ci;
-	
+
 	count = 0;
 	while ((pid_dead = waitpid(-1, NULL, WNOHANG)) > 0) {
 		FOREACH_CHILD(sd) {
@@ -810,7 +810,7 @@ supervisor_children_register(const gchar *key, const gchar *cmd, GError **error)
 	(void) supervisor_limit_get(SUPERV_LIMIT_THREAD_STACK, &(sd->rlimits.stack_size));
 	(void) supervisor_limit_get(SUPERV_LIMIT_MAX_FILES,    &(sd->rlimits.nb_files));
 	(void) supervisor_limit_get(SUPERV_LIMIT_CORE_SIZE,    &(sd->rlimits.core_size));
-	
+
 	/*ring insertion*/
 	sd->next = SRV_BEACON.next;
 	SRV_BEACON.next = sd;
@@ -850,7 +850,7 @@ supervisor_children_kill_disabled(void)
 	FOREACH_CHILD(sd) {
 		/* Stop child that needs to be restarted */
 		if (FLAG_HAS(sd,MASK_RESTART))
-			_child_set_flag(sd, MASK_STARTED, FALSE);	
+			_child_set_flag(sd, MASK_STARTED, FALSE);
 
 		if (!_child_should_be_up(sd)) {
 			if (sd->pid > 0) {
@@ -860,7 +860,7 @@ supervisor_children_kill_disabled(void)
 			}
 		}
 	}
-	
+
 	return count;
 }
 
@@ -943,7 +943,7 @@ supervisor_children_repair_all(void)
 			count ++;
 		}
 	}
-	
+
 	errno = 0;
 	return count;
 }

--- a/lib/children.c
+++ b/lib/children.c
@@ -629,12 +629,6 @@ supervisor_children_start_enabled(void *udata, supervisor_cb_f cb)
 }
 
 guint
-supervisor_children_startall(void *udata, supervisor_cb_f cb)
-{
-	return supervisor_children_start_enabled(udata, cb);
-}
-
-guint
 supervisor_children_mark_obsolete(void)
 {
 	guint count;
@@ -660,26 +654,6 @@ supervisor_children_disable_obsolete(void)
 		if (FLAG_HAS(sd,MASK_OBSOLETE)) {
 			FLAG_SET(sd, MASK_DISABLED);
 			count ++;
-		}
-	}
-
-	return count;
-}
-
-guint
-supervisor_children_kill_obsolete(void)
-{
-	guint count;
-	struct child_s *sd;
-
-	count = 0U;
-
-	FOREACH_CHILD(sd) {
-		if (FLAG_HAS(sd,MASK_OBSOLETE)) {
-			if (sd->pid > 0) {
-				_child_stop(sd);
-				count ++;
-			}
 		}
 	}
 

--- a/lib/children.c
+++ b/lib/children.c
@@ -38,7 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 time_t supervisor_default_delay_KILL = SUPERVISOR_DEFAULT_TIMEOUT_KILL;
 
 static time_t _monotonic_seconds(void) {
-    return g_get_monotonic_time() / G_TIME_SPAN_SECOND;
+	return g_get_monotonic_time() / G_TIME_SPAN_SECOND;
 }
 
 /**
@@ -462,8 +462,8 @@ _child_stop(struct child_s *sd)
 		if (sd->first_kill_attempt == 0)
 			sd->first_kill_attempt = now;
 		if (sd->delay_before_KILL > 0
-                && sd->first_kill_attempt > 0
-                && (now - sd->first_kill_attempt) > sd->delay_before_KILL) {
+				&& sd->first_kill_attempt > 0
+				&& (now - sd->first_kill_attempt) > sd->delay_before_KILL) {
 			DEBUG("Service [%s] did not exit after 60s, sending SIGKILL", sd->key);
 			kill(sd->pid, SIGKILL);
 		} else {
@@ -767,7 +767,7 @@ supervisor_children_register(const gchar *key, const gchar *cmd)
 	}
 
 	g_strlcpy(sd->key, key, sizeof(sd->key)-1);
-    sd->delay_before_KILL = supervisor_default_delay_KILL;
+	sd->delay_before_KILL = supervisor_default_delay_KILL;
 	sd->flags = MASK_STARTED|MASK_RESPAWN|MASK_DELAYED;
 	sd->working_directory = g_get_current_dir();
 	sd->command = g_strdup(cmd);

--- a/lib/command.c
+++ b/lib/command.c
@@ -25,7 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-#include <sys/time.h>
 #include <unistd.h>
 
 #include <glib.h>

--- a/lib/gridinit-utils.h
+++ b/lib/gridinit-utils.h
@@ -102,7 +102,7 @@ guint supervisor_children_mark_obsolete(void);
    Will send SIGKILL until expiration, then SIGTERM. */
 guint supervisor_children_kill_disabled(void);
 
-/* starts allt the stopped services in a state proper to be restarted */
+/* starts all the stopped services in a state proper to be restarted */
 guint supervisor_children_start_enabled(void *udata, supervisor_cb_f cb);
 
 /* Sets the 'enabled' flag on the service */

--- a/lib/gridinit-utils.h
+++ b/lib/gridinit-utils.h
@@ -32,6 +32,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # include <sys/types.h>
 # include <unistd.h>
 
+extern time_t supervisor_default_delay_KILL;
+
 /* Children monitoring ----------------------------------------------------- */
 
 enum supervisor_limit_e {
@@ -93,8 +95,7 @@ guint supervisor_children_killall(int sig);
 
 guint supervisor_children_catharsis(void *udata, supervisor_cb_f cb);
 
-gboolean supervisor_children_register(const gchar *key, const gchar *cmd,
-		GError **error);
+gboolean supervisor_children_register(const gchar *key, const gchar *cmd);
 
 /**
  * Marks the services still obsolete as DISABLED and to be stopped.

--- a/lib/gridinit-utils.h
+++ b/lib/gridinit-utils.h
@@ -241,6 +241,8 @@ int supervisor_children_get_info(const gchar *key, struct child_info_s *ci);
  */
 int supervisor_children_set_ids(const gchar *key, gint32 uid, gint32 gid);
 
+int supervisor_children_set_delay_sigkill(const char *key, time_t delay);
+
 /* Fork and pipe ----------------------------------------------------------- */
 
 /** 

--- a/lib/gridinit-utils.h
+++ b/lib/gridinit-utils.h
@@ -75,19 +75,12 @@ typedef void (supervisor_cb_f) (void *udata, struct child_info_s *ci);
 
 void supervisor_children_init(void);
 
-/**
- * Sets an optional function that will be used just after the fork
- */
+/* Sets an optional function that will be used just after the fork */
 void supervisor_set_callback_postfork(supervisor_postfork_f *cb, void *udata);
 
 void supervisor_children_fini(void);
 
 guint supervisor_children_cleanall(void);
-
-/**
- * @deprecated use supervisor_children_kill() instead
- */
-guint supervisor_children_startall(void *udata, supervisor_cb_f cb);
 
 void supervisor_children_stopall(guint max_retries);
 
@@ -97,201 +90,87 @@ guint supervisor_children_catharsis(void *udata, supervisor_cb_f cb);
 
 gboolean supervisor_children_register(const gchar *key, const gchar *cmd);
 
-/**
- * Marks the services still obsolete as DISABLED and to be stopped.
- * Services still carry the OBSOLETE flag after this step.
- */
+/* Marks the services still obsolete as DISABLED and to be stopped.
+   Services still carry the OBSOLETE flag after this step. */
 guint supervisor_children_disable_obsolete(void);
 
-/**
- * @deprecated will be deleted soon, please use supervisor_children_disable_obsolete() then supervisor_children_kill_disabled()
- */
-guint supervisor_children_kill_obsolete(void);
-
-/**
- * Mark all the services as obsolete.
- * This is used when reloading a configuration.
- */
+/* Mark all the services as obsolete. This is used when reloading a config. */
 guint supervisor_children_mark_obsolete(void);
 
-/**
- * Stops the UP services that are in state that does not allow them to run.
- *
- * This includes services DOWN, BROKEN, STOPPED, DISABLED.
- * Will send SIGKILL until expiration, then SIGTERM.
- */
+/* Stops the UP services that are in state that does not allow them to run.
+   This includes services DOWN, BROKEN, STOPPED, DISABLED.
+   Will send SIGKILL until expiration, then SIGTERM. */
 guint supervisor_children_kill_disabled(void);
 
-/**
- * starts allt the stopped services in a state proper to be restarted
- */
+/* starts allt the stopped services in a state proper to be restarted */
 guint supervisor_children_start_enabled(void *udata, supervisor_cb_f cb);
 
-/**
- * Sets the 'enabled' flag on the service
- */
+/* Sets the 'enabled' flag on the service */
 int supervisor_children_enable(const char *key, gboolean enable);
 
-/**
- * Sets the 'autorespawn' flag on this service
- */
+/* Sets the 'autorespawn' flag on this service */
 int supervisor_children_set_respawn(const char *key, gboolean enabled);
 
-/**
- * Marks the service to be started or stopped.
- */
+/* Marks the service to be started or stopped.  */
 int supervisor_children_status(const char *key, gboolean to_be_started);
 
-/**
- * Starts a service that died too often
- */
+/* Starts a service that died too often */
 int supervisor_children_repair(const char *key);
 
-/**
- * Sets/Disable the "delayed restart" behavior for a process
- */
+/* Sets/Disable the "delayed restart" behavior for a process */
 int supervisor_children_set_delay(const char *key, gboolean enabled);
 
-/**
- * Calls supervisor_children_repair() on each broken service
- */
+/* Calls supervisor_children_repair() on each broken service */
 int supervisor_children_repair_all(void);
 
-/**
- * Restart a service
- */
+/* Restart a service */
 int supervisor_children_restart(const char *key);
 
-/**
- *
- */
 int supervisor_children_set_limit(const gchar *key,
 		enum supervisor_limit_e what, gint64 value);
 
-/**
- * Runs the children list and call the callback fnction on each
- * element
- */
+/* Runs the children list and call the callback fnction on each element */
 gboolean supervisor_run_services(void *ptr, supervisor_cb_f callback);
 
-/**
- *
- * @param key
- * @param dir
- * @return
- */
 int supervisor_children_set_working_directory(const gchar *key,
 		const gchar *dir);
 
-/**
- * 
- * @param key
- * @param envkey
- * @param envval
- * @param separator if not 0, keep the previous value and prepends the new value
- * @return
- */
 int supervisor_children_setenv(const gchar *key, const gchar *envkey,
 	const gchar *envval, gchar separator);
 
 void supervisor_children_inherit_env(const gchar *key);
 
-/**
- *
- * @param key
- * @return
- */
 int supervisor_children_clearenv(const gchar *key);
 
-/**
- * @param key
- * @param flags
- * @return
- */
 int supervisor_children_set_user_flags(const gchar *key, guint32 flags);
 
-/**
- * @param key
- * @param flags
- * @return
- */
 int supervisor_children_del_user_flags(const gchar *key, guint32 flags);
 
-/**
- * @param key
- * @param group NULL to clear the group
- * @return
- */
 int supervisor_children_set_group(const gchar *key, const gchar *group);
 
-/**
- *
- * @param key
- * @param ci
- * @return
- */
 int supervisor_children_get_info(const gchar *key, struct child_info_s *ci);
 
-/**
- *
- * @param key
- * @param uid
- * @param gid
- * @return
- */
 int supervisor_children_set_ids(const gchar *key, gint32 uid, gint32 gid);
 
 int supervisor_children_set_delay_sigkill(const char *key, time_t delay);
 
 /* Fork and pipe ----------------------------------------------------------- */
 
-/** 
- *
- * @param str_cmd
- * @return
- */
 int command_get_pipe(const gchar *str_cmd);
 
 /* Privileges -------------------------------------------------------------- */
 
-/**
- *
- * @param user_name
- * @param group_name
- * @param error
- * @return
- */
 gboolean supervisor_rights_init(const char *user_name, const char *group_name,
 		GError ** error);
 
-/**
- *
- * @return
- */
 int supervisor_rights_gain(void);
 
-/**
- *
- * @return
- */
 int supervisor_rights_lose(void);
 
 /* Processus limits */
 
-/**
- *
- * @param what
- * @param value
- * @return
- */
 int supervisor_limit_set(enum supervisor_limit_e what, gint64 value);
 
-/**
- *
- * @param what
- * @param value
- * @return
- */
 int supervisor_limit_get(enum supervisor_limit_e what, gint64 *value);
 
 #endif

--- a/main/alerting.c
+++ b/main/alerting.c
@@ -45,38 +45,43 @@ gridinit_alerting_configure(const gchar *path, const gchar *symbol,
 	TRACE("trying to configure the alerting with the module [%s] and the symbol [%s]",
 		path, symbol);
 	if (!symbol || !path) {
-		if (err)
+		if (err) {
 			*err = g_error_printf(LOG_DOMAIN, 500, "Invalid parameter");
-			return FALSE;
+		}
+		return FALSE;
 	}
 	if (module != NULL) {
-		if (err)
+		if (err) {
 			*err = g_error_printf(LOG_DOMAIN, 500, "Module already loaded");
+		}
 		return FALSE;
 	}
 
 	/* Open the module and locate the exported symbol */
 	if (NULL == (module = g_module_open (path, 0))) {
-		if (err)
+		if (err) {
 			*err = g_error_printf(LOG_DOMAIN, 500,
 				"Cannot load the plug-in from file %s (%s)",
 				path, g_module_error());
+		}
 		return FALSE;
 	}
 
 	gpointer pointer = NULL;
 	if (!g_module_symbol(module, symbol, &pointer) || !pointer) {
-		if (err)
+		if (err) {
 			*err = g_error_printf(LOG_DOMAIN, 500,
 				"Cannot get the exported structure (%s) from the plug-in %p (%s)",
 				symbol, (void*)module, g_module_error());
+		}
 		return FALSE;
 	}
 
 	handle = pointer;
-	if (handle->init)
+	if (handle->init) {
 		handle->init(handle->module_data, ht_params);
-	
+	}
+
 	return TRUE;
 }
 

--- a/main/cnx.c
+++ b/main/cnx.c
@@ -35,7 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/un.h>

--- a/main/gridinit.c
+++ b/main/gridinit.c
@@ -97,7 +97,6 @@ static volatile int flag_help = 0;
 static volatile int flag_quiet = 0;
 static volatile int flag_daemon = 0;
 static volatile int flag_running = ~0;
-static volatile int flag_cfg_reload = 0;
 static volatile int flag_check_socket = 0;
 static volatile int flag_more_verbose = 0;
 

--- a/main/gridinit.c
+++ b/main/gridinit.c
@@ -54,9 +54,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "./gridinit_alerts.h"
 #include "../lib/gridinit-internals.h"
 
-#define USERFLAG_ONDIE_EXIT                                          0x00000001
-#define USERFLAG_PROCESS_DIED                                        0x00000002
-#define USERFLAG_PROCESS_RESTARTED				     0x00000004
+#define USERFLAG_ONDIE_EXIT        0x00000001
+#define USERFLAG_PROCESS_DIED      0x00000002
+#define USERFLAG_PROCESS_RESTARTED 0x00000004
 
 #define BOOL(i) ((i)!=0)
 
@@ -1227,7 +1227,7 @@ _cfg_section_service(GKeyFile *kf, const gchar *section, GError **err)
 	 * being reloaded. */
 	already_exists = _service_exists(str_key);
 
-	if (!supervisor_children_register(str_key, str_command, err))
+	if (!supervisor_children_register(str_key, str_command))
 		goto label_exit;
 
 	/* Enables or not. This is a lock controlled by the configuration

--- a/main/gridinit_cmd.c
+++ b/main/gridinit_cmd.c
@@ -631,12 +631,13 @@ help(char **args)
 	g_print("\n COMMANDS:\n");
 	g_print("  status* : Displays the status of the given processes or groups\n");
 	g_print("  start   : Starts the given processes or groups, even if broken\n");
-	g_print("  stop    : Stops the given processes or groups, they won't be automatically\n");
+	g_print("  kill    : Stops the given processes or groups, they won't be automatically\n");
 	g_print("            restarted even after a configuration reload\n");
-	g_print("  restart : Restart the given processes or groups\n");
-	g_print("  reload  : reloads the configuration, stopping obsolete processes, starting\n");
+	g_print("  stop    : Calls 'kill' until the children exit\n");
+	g_print("  restart : Restarts the given processes or groups\n");
+	g_print("  reload  : Reloads the configuration, stopping obsolete processes, starting\n");
 	g_print("            the newly discovered. Broken or stopped processes are not restarted\n");
-	g_print("  repair  : removes the broken flag set on a process. Start must be called to\n");
+	g_print("  repair  : Removes the broken flag set on a process. Start must be called to\n");
 	g_print("            restart the process.\n");
 	g_print("with ID the key of a process, or '@GROUP', with GROUP the name of a process\n");
 	g_print("group\n");

--- a/main/gridinit_internals.h
+++ b/main/gridinit_internals.h
@@ -20,6 +20,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef  __GRIDINIT_INTERNALS_H__
 # define __GRIDINIT_INTERNALS_H__ 1
 
+#ifndef  CFG_KEY_DELAY_KILL
+# define CFG_KEY_DELAY_KILL "delay_sigkill"
+#endif
+
 # ifndef  GRIDINIT_SOCK_PATH
 #  define GRIDINIT_SOCK_PATH "/var/run/gridinit.sock"
 # endif


### PR DESCRIPTION
Helps fixing #13 

The old-style "fire & forget" `stop`command is still available under the name `kill`.