### PR TITLE
Delete on_die=exit option

### DIFF
--- a/gridinit.conf
+++ b/gridinit.conf
@@ -79,7 +79,7 @@ command=gridinit_testcmd /tmp/key0.out 5
 # are sent.
 enabled=true
 
-# on_die : 'cry' | 'respawn' | 'exit'
+# on_die : 'cry' | 'respawn'
 # Optional and dangerous directive telling what to do with the whole
 # gridinit when the current service dies, whatever the normality of
 # the death.

--- a/lib/children.c
+++ b/lib/children.c
@@ -868,7 +868,7 @@ supervisor_children_enable(const char *key, gboolean enable)
 
 		/* We reset the 'last_start_attempt' field. This is necessary
 		 * to explicitely restart services configured with the 'cry'
-		 * or 'exit' value for their 'on_die' parameter */
+		 * value for their 'on_die' parameter */
 		sd->last_start_attempt = 0;
 	}
 

--- a/main/gridinit.c
+++ b/main/gridinit.c
@@ -54,7 +54,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "./gridinit_alerts.h"
 #include "../lib/gridinit-internals.h"
 
-#define USERFLAG_ONDIE_EXIT        0x00000001
 #define USERFLAG_PROCESS_DIED      0x00000002
 #define USERFLAG_PROCESS_RESTARTED 0x00000004
 
@@ -208,13 +207,6 @@ static void
 alert_proc_died(void *udata, struct child_info_s *ci)
 {
 	(void) udata;
-
-	/* if the user_flags on the process contain the on_die:exit flag,
-	 * then we mark the gridinit to stop */
-	if (ci->user_flags & USERFLAG_ONDIE_EXIT) {
-		supervisor_children_enable(ci->key, FALSE);
-		flag_running = FALSE;
-	}
 
 	if (ci->started)
 		supervisor_children_set_user_flags(ci->key, USERFLAG_PROCESS_DIED);
@@ -1249,10 +1241,6 @@ _cfg_section_service(GKeyFile *kf, const gchar *section, GError **err)
 		if (0 == g_ascii_strcasecmp(str_ondie, "cry")) {
 			if (0 > supervisor_children_set_respawn(str_key, FALSE))
 				WARN("Failed to make [%s] respawn : %s", str_key, strerror(errno));
-		}
-		else if (0 == g_ascii_strcasecmp(str_ondie, "exit")) {
-			supervisor_children_set_user_flags(str_key, USERFLAG_ONDIE_EXIT);
-			supervisor_children_set_respawn(str_key, FALSE);
 		}
 		else if (0 == g_ascii_strcasecmp(str_ondie, "respawn"))
 			supervisor_children_set_respawn(str_key, TRUE);

--- a/main/gridinit.c
+++ b/main/gridinit.c
@@ -1236,7 +1236,7 @@ _cfg_section_service(GKeyFile *kf, const gchar *section, GError **err)
 			WARN("Failed to set 'tobestarted/tobestopped' for [%s] : %s", str_key, strerror(errno));
 	}
 
-	/* on_die management. Respawn, cry, or abort */
+	/* on_die management. Respawn, cry */
 	if (str_ondie) {
 		if (0 == g_ascii_strcasecmp(str_ondie, "cry")) {
 			if (0 > supervisor_children_set_respawn(str_key, FALSE))


### PR DESCRIPTION
Fix #23.
Disable option for that children can't kill the gridinit of a node