### PR TITLE
Various fixes

### DIFF
--- a/main/children.c
+++ b/main/children.c
@@ -357,7 +357,14 @@ _child_exec(struct child_s *sd, int argc, char ** args)
 	/* If the target command is just a filename, then try to find
 	 * it in the PATH that could have been set for this command */
 	env = _child_build_env(sd);
-	supervisor_children_cleanall();
+
+	/* JFS: No need to free the allocated memory of gridinit, execve will do. */
+	/* supervisor_children_cleanall(); */
+
+	/* JFS: the internal sockets of libdill do not carry the O_CLOEXEC flag.
+	 *      We want to avoid any FD leak to the children. */
+	for (int i=3; i<8; i++)
+		close(i);
 
 	if (g_path_is_absolute(cmd))
 		real_cmd = g_strdup(cmd);

--- a/main/children.c
+++ b/main/children.c
@@ -387,7 +387,7 @@ _child_start(struct child_s *sd, void *udata, supervisor_cb_f cb)
 	typeof(errno) errsav;
 	gint argc;
 	gchar **args;
-	struct my_rlimits_s saved_limits;
+	struct my_rlimits_s saved_limits = {};
 
 	if (!sd || !sd->command) {
 		errno = EINVAL;
@@ -398,8 +398,6 @@ _child_start(struct child_s *sd, void *udata, supervisor_cb_f cb)
 		errno = EINVAL;
 		return -1;
 	}
-
-	bzero(&saved_limits, sizeof(saved_limits));
 
 	sd->last_start_attempt = _monotonic_seconds();
 	sd->last_start = time(0);
@@ -789,7 +787,7 @@ supervisor_children_register(const gchar *key, const gchar *cmd)
 		return FALSE;
 	}
 
-	g_strlcpy(sd->key, key, sizeof(sd->key)-1);
+	g_strlcpy(sd->key, key, sizeof(sd->key));
 	sd->delay_before_KILL = supervisor_default_delay_KILL;
 	sd->flags = MASK_STARTED|MASK_RESPAWN|MASK_DELAYED;
 	sd->working_directory = g_get_current_dir();
@@ -1134,9 +1132,11 @@ supervisor_children_set_group(const gchar *key, const gchar *group)
 		return -1;
 	}
 
-	bzero(sd->group, sizeof(sd->group));
-	if (group)
-		g_strlcpy(sd->group, group, sizeof(sd->group)-1);
+	if (group) {
+		g_strlcpy(sd->group, group, sizeof(sd->group));
+	} else {
+		memset(sd->group, 0, sizeof(sd->group));
+	}
 	errno = 0;
 	return 0;
 }

--- a/main/gridinit.c
+++ b/main/gridinit.c
@@ -762,9 +762,7 @@ _group_is_accepted(gchar *str_key, gchar *str_group)
 static gboolean
 _service_exists(const gchar *key)
 {
-	struct child_info_s ci;
-
-	bzero(&ci, sizeof(ci));
+	struct child_info_s ci = {};
 	return 0 == supervisor_children_get_info(key, &ci);
 }
 
@@ -970,39 +968,33 @@ _cfg_section_default(GKeyFile *kf, const gchar *section, GError **err)
 		else if (!g_ascii_strcasecmp(*p_key, CFG_KEY_PATH_WORKINGDIR)) {
 			if (!g_file_test(*p_key, G_FILE_TEST_IS_DIR|G_FILE_TEST_IS_EXECUTABLE))
 				WARN("Default working directory does not exist yet [%s]", *p_key);
-			bzero(default_working_directory, sizeof(default_working_directory));
-			g_strlcpy(default_working_directory, str, sizeof(default_working_directory)-1);
+			g_strlcpy(default_working_directory, str, sizeof(default_working_directory));
 		}
 		else if (!g_ascii_strcasecmp(*p_key, CFG_KEY_PATH_PIDFILE)) {
-			bzero(pidfile_path, sizeof(pidfile_path));
-			g_strlcpy(pidfile_path, str, sizeof(pidfile_path)-1);
+			g_strlcpy(pidfile_path, str, sizeof(pidfile_path));
 		}
 		else if (!g_ascii_strcasecmp(*p_key, CFG_KEY_LISTEN)) {
-			if (str[0] == '/')
+			if (str[0] == '/') {
 				g_strlcpy(sock_path, str, sizeof(sock_path));
-			else
+			} else {
 				g_printerr("section=%s, key=listen : not a UNIX path, ignored! [%s]\n",
 					section, str);
+			}
 		}
 		else if (!g_ascii_strcasecmp(*p_key, CFG_KEY_USER)) {
-			bzero(buf_user, sizeof(buf_user));
-			g_strlcpy(buf_user, str, sizeof(buf_user)-1);
+			g_strlcpy(buf_user, str, sizeof(buf_user));
 		}
 		else if (!g_ascii_strcasecmp(*p_key, CFG_KEY_GROUP)) {
-			bzero(buf_group, sizeof(buf_group));
-			g_strlcpy(buf_group, str, sizeof(buf_group)-1);
+			g_strlcpy(buf_group, str, sizeof(buf_group));
 		}
 		else if (!g_ascii_strcasecmp(*p_key, CFG_KEY_UID)) {
-			bzero(buf_uid, sizeof(buf_uid));
-			g_strlcpy(buf_uid, str, sizeof(buf_uid)-1);
+			g_strlcpy(buf_uid, str, sizeof(buf_uid));
 		}
 		else if (!g_ascii_strcasecmp(*p_key, CFG_KEY_GID)) {
-			bzero(buf_gid, sizeof(buf_gid));
-			g_strlcpy(buf_gid, str, sizeof(buf_gid)-1);
+			g_strlcpy(buf_gid, str, sizeof(buf_gid));
 		}
 		else if (!g_ascii_strcasecmp(*p_key, CFG_KEY_INCLUDES)) {
-			bzero(buf_includes, sizeof(buf_includes));
-			g_strlcpy(buf_includes, str, sizeof(buf_includes)-1);
+			g_strlcpy(buf_includes, str, sizeof(buf_includes));
 		}
 		else if (!g_ascii_strcasecmp(*p_key, CFG_KEY_GROUPSONLY)) {
 			_str_set_array(FALSE, &groups_only_cfg, str);
@@ -1178,11 +1170,7 @@ label_exit:
 static guint16
 compute_thread_id(GThread *thread)
 {
-	union {
-		void *p;
-		guint16 u[4];
-	} bulk;
-	memset(&bulk, 0, sizeof(bulk));
+	union { void *p; guint16 u[4]; } bulk = {};
 	bulk.p = thread;
 	return (bulk.u[0] ^ bulk.u[1]) ^ (bulk.u[2] ^ bulk.u[3]);
 }
@@ -1398,11 +1386,10 @@ static gboolean
 is_gridinit_running(const gchar *path)
 {
 	int rc, usock;
-	struct sockaddr_un sun;
+	struct sockaddr_un sun = {};
 
-	bzero(&sun, sizeof(sun));
 	sun.sun_family = AF_UNIX;
-	g_strlcpy(sun.sun_path, path, sizeof(sun.sun_path) - 1);
+	g_strlcpy(sun.sun_path, path, sizeof(sun.sun_path));
 
 	if (0 > (usock = socket(PF_UNIX, SOCK_STREAM, 0)))
 		return FALSE;

--- a/main/gridinit.c
+++ b/main/gridinit.c
@@ -1557,6 +1557,9 @@ label_exit:
 	supervisor_children_fini();
 
 	g_free(config_path);
+	if (*pidfile_path) {
+		unlink(pidfile_path);
+	}
 	closelog();
 	return rc;
 }


### PR DESCRIPTION
* gridinit_cmd: Set the exit status to 1 when the socket cannot be reached
* gridinit: Remove the socket at exit
* gridinit: Remove the pidfile at exit
* gridinit: Close file descriptor between fork() and execve()
* gridinit: Lighter variable associations

/cc @jkasarherou 