### PR TITLE
Adapt the buffer size for getpwnam_r and getgrnam_r

### DIFF
--- a/main/gridinit.c
+++ b/main/gridinit.c
@@ -667,7 +667,7 @@ static gboolean
 uid_exists(const gchar *str, gint32 *id)
 {
 	struct passwd pwd, *p_pwd;
-	gchar buf[1024];
+	gchar buf[32768];
 
 	if (_str_is_num(str)) {
 		gint64 i64;
@@ -689,7 +689,7 @@ static gboolean
 gid_exists(const gchar *str, gint32 *id)
 {
 	struct group grp, *p_grp;
-	gchar buf[1024];
+	gchar buf[32768];
 
 	if (_str_is_num(str)) {
 		gint64 i64;


### PR DESCRIPTION
In some cases, with large /etc/group or /etc/passwd files, calls to
getgrnam_r (in gid_exists) or getpwnam_r (in uid_exists) leads to
errno 34 and fail to start the service.

This fix rises the buffer size but it would be better to rise it
dynamically depending on return value. See man(3) getgrnam_r.